### PR TITLE
Fix import paths

### DIFF
--- a/main.go
+++ b/main.go
@@ -18,9 +18,9 @@ import (
 	"strconv"
 	"strings"
 
-	"code.google.com/p/goplan9/plan9"
-	"code.google.com/p/goplan9/plan9/acme"
-	"code.google.com/p/goplan9/plan9/client"
+	"9fans.net/go/plan9"
+	"9fans.net/go/acme"
+	"9fans.net/go/plan9/client"
 
 	"code.google.com/p/go.tools/go/loader"
 	"code.google.com/p/go.tools/oracle"

--- a/main.go
+++ b/main.go
@@ -22,8 +22,8 @@ import (
 	"9fans.net/go/acme"
 	"9fans.net/go/plan9/client"
 
-	"code.google.com/p/go.tools/go/loader"
-	"code.google.com/p/go.tools/oracle"
+	"golang.org/x/tools/go/loader"
+	"golang.org/x/tools/oracle"
 )
 
 var ld = loader.Config{SourceImports: true}


### PR DESCRIPTION
The plan9, acme and go tools libraries have moved. Isn't it fun?
